### PR TITLE
Optimization: Deduplicate constant index during compilation

### DIFF
--- a/file.lox
+++ b/file.lox
@@ -13,7 +13,8 @@
 
 
 var breakfast = "beignets";
+breakfast = "oops woke up late, anyways eating ";
 var beverage = "cafe au lait";
-breakfast = "beignets with " + beverage;
+breakfast = breakfast + "beignets with " + beverage;
 
 print breakfast;

--- a/src/chunk.zig
+++ b/src/chunk.zig
@@ -42,7 +42,7 @@ pub const Chunk = struct {
         }
         dbg("]", .{});
         dbg("\nConstants:\n", .{});
-        for (self.constants.values, 0..) |value, i| {
+        for (self.constants.values[0..self.constants.count], 0..) |value, i| {
             dbg("idx {d}: {any}, ", .{ i, value });
         }
         dbg("\n", .{});

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -277,14 +277,20 @@ fn statement() void {
 }
 /// Build a non-interned constant for a variable name and return its index in the chunk's constants table.
 fn identifierConstant(token: *const Token, intern_table: *Table) usize {
-    const obj = (Object.newString(
+    const obj_intern = (Object.newString(
         parser.vm,
         &[_][]const u8{token.lexeme},
         intern_table,
-    ) catch @panic(HEAP_FAIL)).obj;
-    return makeConstant(
-        Value{ .Obj = obj },
-    );
+    ) catch @panic(HEAP_FAIL));
+    const obj, _ = .{ obj_intern.obj, obj_intern.interned };
+    const index_at_table = compilerConstantTable.get(obj.asObjString().?);
+    if (index_at_table) |present| {
+        return @intFromFloat(present.asNumber().?);
+    }
+    const index = makeConstant(Value{ .Obj = obj });
+    const isNewKey = compilerConstantTable.set(obj.asObjString().?, Value{ .Number = @floatFromInt(index) }) catch @panic("Out of memory interning string constant");
+    std.debug.assert(isNewKey);
+    return index;
 }
 fn parseVariable(errMessage: []const u8, intern_table: *Table) usize {
     consume(TokenType.Identifier, errMessage);

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -407,6 +407,8 @@ pub fn compile(
     parser.allocator = allocator;
     parser.vm = vm;
     compilerStringTable = Table.init(allocator);
+    // NOTE: ObjString still uses loxHash, but the HashTable uses Clhash if available. This doesn't matter for checking values
+    // but should be cleared up in the future.
     compilerConstantTable = Table.initWithHashFn(allocator, if (lib.hasClhash) .clhash else .default);
     defer compilerConstantTable.deinit();
     if (opts) |o| {

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -401,7 +401,7 @@ pub fn compile(
     parser.allocator = allocator;
     parser.vm = vm;
     compilerStringTable = Table.init(allocator);
-    compilerConstantTable = Table.initWithHashFn(allocator, .clhash);
+    compilerConstantTable = Table.initWithHashFn(allocator, if (lib.hasClhash) .clhash else .default);
     defer compilerConstantTable.deinit();
     if (opts) |o| {
         if (o.debug) {
@@ -461,6 +461,7 @@ const HEAP_FAIL = "fatal: failed to heap allocate";
 const CompilerError = @import("error.zig").CompilerError;
 const Table = @import("table.zig").Table;
 const VM = @import("vm.zig").VM;
+const lib = @import("root.zig");
 
 /// Lowest to highest precedence
 const Precedence = enum {

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1,5 +1,7 @@
 var debug_level: u8 = 0;
 var compilerStringTable: Table = undefined;
+var compilerConstantTable: Table = undefined;
+
 var parser: Parser = Parser{
     // This will get overwritten by advance() and pushed into .previous
     // For first byte, the line is fetched as parser.previous.line, so we need this
@@ -399,6 +401,8 @@ pub fn compile(
     parser.allocator = allocator;
     parser.vm = vm;
     compilerStringTable = Table.init(allocator);
+    compilerConstantTable = Table.initWithHashFn(allocator, .clhash);
+    defer compilerConstantTable.deinit();
     if (opts) |o| {
         if (o.debug) {
             // Allocate DebugInfo on the heap

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -408,8 +408,9 @@ pub fn compile(
     parser.vm = vm;
     compilerStringTable = Table.init(allocator);
     // NOTE: ObjString still uses loxHash, but the HashTable uses Clhash if available. This doesn't matter for checking values
-    // but should be cleared up in the future.
-    compilerConstantTable = Table.initWithHashFn(allocator, if (lib.hasClhash) .clhash else .default);
+    // but should be cleared up in the future. For now we just stick to the defaults...
+    // compilerConstantTable = Table.initWithHashFn(allocator, if (lib.hasClhash) .clhash else .default);
+    compilerConstantTable = Table.initWithHashFn(allocator, .default); // Use same hash across table/objstring
     defer compilerConstantTable.deinit();
     if (opts) |o| {
         if (o.debug) {

--- a/src/root.zig
+++ b/src/root.zig
@@ -32,12 +32,14 @@ pub const ClHash = if (hasClhash) struct {
 
     pub fn hash(key: []const u8) u64 {
         std.debug.assert(RANDOM != null);
+        std.debug.print("\n\n\n\nUsing CLHash for key: {s}\n", .{key});
         return clhash.clhash(RANDOM, key.ptr, key.len);
     }
 } else struct {
     pub fn init() void {}
-    pub fn hash(_: []const u8) u64 {
-        @compileError("CLHash not available (set has_clhash in build options)");
+    pub fn hash(s: []const u8) u64 {
+        std.debug.print("CLHash is not enabled, using fallback hash function.\n", .{});
+        return @import("table.zig").loxHash(s);
     }
 };
 

--- a/src/table.zig
+++ b/src/table.zig
@@ -11,6 +11,7 @@ pub const Table = struct {
     count: usize, // entries + tombstones
     capacity: usize,
     entries: []align(8) Entry,
+    hash_fn: *const fn ([]const u8) u64 = loxHash,
 
     pub fn init(allocator: std.mem.Allocator) Table {
         return Table{
@@ -18,6 +19,18 @@ pub const Table = struct {
             .count = 0,
             .capacity = 0,
             .entries = undefined,
+        };
+    }
+    pub fn initWithHashFn(allocator: std.mem.Allocator, hash_fn: enum { clhash, loxhash, default }) Table {
+        return Table{
+            .allocator = allocator,
+            .count = 0,
+            .capacity = 0,
+            .entries = undefined,
+            .hash_fn = switch (hash_fn) {
+                .clhash => clhash,
+                .default, .loxhash => loxHash,
+            },
         };
     }
     pub fn deinit(self: *Table) void {
@@ -127,7 +140,7 @@ pub fn tableAddAll(from: *Table, to: *Table) !void {
 }
 pub fn tableFindString(table: *Table, chars: []const u8) ?*ObjString {
     if (table.count == 0) return null;
-    const hashcode = hasher(chars); // Switch to loxHash because chars is not guaranteed to be 8 byte aligned
+    const hashcode = table.hash_fn(chars); // Switch to loxHash because chars is not guaranteed to be 8 byte aligned
     var idx = hashcode % table.capacity;
     while (true) : (idx = @mod(idx + 1, table.capacity)) {
         const e = &table.entries[idx];

--- a/src/value.zig
+++ b/src/value.zig
@@ -17,12 +17,12 @@ pub const Value = union(enum) {
         switch (self) {
             .Number => try writer.print("Number {d}", .{self.Number}),
             .String => try writer.print("String \"{s}\"", .{self.String}),
-            .Bool => try writer.print("Boolean {s}", .{if (self.Bool) "true" else "false"}),
+            .Bool => |b| try writer.print("Boolean {any}", .{b}),
             .Nil => try writer.writeAll("Nil"),
             .Obj => try writer.print("{s}", .{self.Obj}),
         }
     }
-    pub fn isNumber(value: *const Value) ?f64 {
+    pub fn asNumber(value: *const Value) ?f64 {
         return switch (value.*) {
             .Number => |num| num,
             else => null,

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -209,7 +209,7 @@ fn run(self: *VM, stack_tracing: bool) RuntimeError!void {
             },
             .NEGATE => {
                 const value: [*]Value = self.stackTop - 1; // Autoscales ptr arithmetic based on @sizeOf(T) for [*]T
-                if (value[0].isNumber()) |num| {
+                if (value[0].asNumber()) |num| {
                     value[0] = Value{ .Number = -num };
                 } else {
                     return RuntimeError.NaN;
@@ -227,7 +227,7 @@ fn run(self: *VM, stack_tracing: bool) RuntimeError!void {
                     try self.push(Value{ .Obj = o.obj });
                     break :add;
                 };
-                if (self.peek(0).isNumber()) |rhs| if (self.peek(1).isNumber()) |lhs| {
+                if (self.peek(0).asNumber()) |rhs| if (self.peek(1).asNumber()) |lhs| {
                     _ = try self.pop();
                     _ = try self.pop();
                     try self.pushNumber(add(lhs, rhs));
@@ -340,7 +340,7 @@ fn peek(self: *VM, distance: usize) Value {
 
 inline fn popNumber(self: *VM) RuntimeError!f64 {
     const value = try self.pop();
-    if (value.isNumber()) |num| {
+    if (value.asNumber()) |num| {
         return num;
     } else {
         return RuntimeError.NaN;


### PR DESCRIPTION
Challenge: The compiler adds a global variable’s name to the constant table as a string every time an identifier is encountered. It creates a new constant each time, even if that variable name is already in a previous slot in the constant table. That’s wasteful in cases where the same variable is referenced multiple times by the same function. That, in turn, increases the odds of filling up the constant table and running out of slots since we allow only ~~256~~ (2^24 for constants, 2^16 for variables) constants in a single chunk.

