### PR TITLE
Implement switch-case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .zig-cache
 zig-out
 .vscode/settings.json
-dev.lox
 clox

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ pool have been exhausted.
 - Expanded Local variables limit to 65536 (u16), no 256 local variable limit, this means we use (u16::max + 1024)*sizeof(Value) [16 bytes] for stack
 - String interning for strings are performed at comptime so zero cost runtime ObjString comparisons. They are only a pointer comparison. It's as fast as it gets.
 - Supports `%` modulo operation.
+- Add support for `switch/case`. Check out [switch-case.lox](programs/switch-case.lox) example. Supports upto 64 nested switch blocks. No `break` keyword required, only one switch case executes. 

--- a/dev.lox
+++ b/dev.lox
@@ -1,0 +1,8 @@
+var a = 22;
+
+switch (a) {
+    case 1: print "not expected";
+    case 22:{ print "22 is the answer"; print "still in case 22";}
+    case 33: print "not expected";
+    default: print "default case";
+}

--- a/dev.lox
+++ b/dev.lox
@@ -3,9 +3,9 @@ var a = 223;
 switch (a) {
     case 1: print "not expected"; // Single-line statement doesn't need braces.
     // Use blocks for multi-line statements.
-    case 220 + 3: { 
-        print "22 is the answer";
-        print "still in case 22";
+    case 220 + 3: switch (4) {
+        case 4: print "nested switch"; // This will execute if the outer case matches.
+        default: print "nested default"; // This will execute if the inner switch doesn't match.
     }
     case 33: print "not expected"; // No `break` required, only one case will match and execute.
     default: print "default case"; // Default case will execute if no other case matches.

--- a/dev.lox
+++ b/dev.lox
@@ -1,8 +1,12 @@
-var a = 22;
+var a = 223;
 
 switch (a) {
-    case 1: print "not expected";
-    case 22:{ print "22 is the answer"; print "still in case 22";}
-    case 33: print "not expected";
-    default: print "default case";
+    case 1: print "not expected"; // Single-line statement doesn't need braces.
+    // Use blocks for multi-line statements.
+    case 220 + 3: { 
+        print "22 is the answer";
+        print "still in case 22";
+    }
+    case 33: print "not expected"; // No `break` required, only one case will match and execute.
+    default: print "default case"; // Default case will execute if no other case matches.
 }

--- a/programs/switch-case.lox
+++ b/programs/switch-case.lox
@@ -1,0 +1,12 @@
+var a = 223;
+
+switch (a) {
+    case 1: print "not expected"; // Single-line statement doesn't need braces.
+    // Use blocks for multi-line statements.
+    case 220 + 3: switch (4) {
+        case 4: print "nested switch"; // This will execute if the outer case matches.
+        default: print "nested default"; // This will execute if the inner switch doesn't match.
+    }
+    case 33: print "not expected"; // No `break` required, only one case will match and execute.
+    default: print "default case"; // Default case will execute if no other case matches.
+}

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -100,7 +100,7 @@ fn emitConstant(value: Value) !void {
         spanInfo(),
     );
 }
-fn emitU16Op(b: op, arg: usize) CompilerError!void {
+fn emitU16Op(b: OpCode, arg: usize) CompilerError!void {
     try emitByte(@intFromEnum(b));
     if (arg > std.math.maxInt(u16)) {
         // Safe: we know that arg is <= 65535
@@ -113,19 +113,22 @@ fn emitU16Op(b: op, arg: usize) CompilerError!void {
 }
 const emit = struct {
     const Self = @This();
-    fn byte(b: op) void {
+    fn op(b: OpCode) void {
         emitByte(@intFromEnum(b)) catch @panic(BYTECODE_FAIL);
     }
-    fn ops(opcodes: []const op) void {
+    fn ops(opcodes: []const OpCode) void {
         for (opcodes) |o| emitByte(@intFromEnum(o)) catch @panic(BYTECODE_FAIL);
     }
     /// Emit a jump instruction.
     /// Returns the offset of the jump placeholder operand in the current chunk.
     /// Use `patchJump` to fill in the jump offset later.
-    fn jump(b: op) usize {
+    fn jump(b: OpCode) usize {
         emitU16Op(b, 0xffff) catch @panic(BYTECODE_FAIL);
         // ^^^ equivalent to `emitByte(b)` followed by `emitByte(0xff)` twice
         return currentChunk().count - 2;
+    }
+    fn byte(b: u8) void {
+        emitByte(b) catch @panic(BYTECODE_FAIL);
     }
 };
 
@@ -155,9 +158,9 @@ fn namedVariable(name: Token, canAssign: bool, intern_table: *Table) void {
     if (cc.resolveLocal(&name)) |arg| {
         if (canAssign and match(TokenType.Equal)) {
             expression();
-            emitU16Op(op.SET_LOCAL, arg) catch @panic(BYTECODE_FAIL);
+            emitU16Op(OpCode.SET_LOCAL, arg) catch @panic(BYTECODE_FAIL);
         } else {
-            emitU16Op(op.GET_LOCAL, arg) catch @panic(BYTECODE_FAIL);
+            emitU16Op(OpCode.GET_LOCAL, arg) catch @panic(BYTECODE_FAIL);
         }
     } else |_| {
         // switch (err) {
@@ -172,9 +175,9 @@ fn namedVariable(name: Token, canAssign: bool, intern_table: *Table) void {
         const uarg = identifierConstant(&name, intern_table);
         if (canAssign and match(TokenType.Equal)) {
             expression();
-            emitU16Op(op.SET_GLOBAL, uarg) catch @panic(BYTECODE_FAIL);
+            emitU16Op(OpCode.SET_GLOBAL, uarg) catch @panic(BYTECODE_FAIL);
         } else {
-            emitU16Op(op.GET_GLOBAL, uarg) catch @panic(BYTECODE_FAIL);
+            emitU16Op(OpCode.GET_GLOBAL, uarg) catch @panic(BYTECODE_FAIL);
         }
         return;
     }
@@ -198,9 +201,9 @@ fn string() void {
 /// Emit a literal from "previous"
 fn literal() void {
     switch (parser.previous.tokenType) {
-        .True => emitByte(@intFromEnum(op.TRUE)) catch @panic(BYTECODE_FAIL),
-        .False => emitByte(@intFromEnum(op.FALSE)) catch @panic(BYTECODE_FAIL),
-        .Nil => emitByte(@intFromEnum(op.NIL)) catch @panic(BYTECODE_FAIL),
+        .True => emit.op(OpCode.TRUE),
+        .False => emit.op(OpCode.FALSE),
+        .Nil => emit.op(OpCode.NIL),
         else => return,
     }
 }
@@ -223,18 +226,18 @@ fn binary() void {
 
     switch (operator_tt) {
         // Arithemtic infix expressions
-        .Plus => emit.byte(op.ADD),
-        .Minus => emit.byte(op.SUBTRACT),
-        .Star => emit.byte(op.MULTIPLY),
-        .Slash => emit.byte(op.DIVIDE),
-        .Modulo => emit.byte(op.MOD),
+        .Plus => emit.op(OpCode.ADD),
+        .Minus => emit.op(OpCode.SUBTRACT),
+        .Star => emit.op(OpCode.MULTIPLY),
+        .Slash => emit.op(OpCode.DIVIDE),
+        .Modulo => emit.op(OpCode.MOD),
         // Logical infix expression
-        .BangEqual => emit.ops(&.{ op.EQUAL, op.NOT }),
-        .EqualEqual => emit.byte(op.EQUAL),
-        .Greater => emit.byte(op.GREATER),
-        .GreaterEqual => emit.ops(&.{ op.LESS, op.NOT }),
-        .Less => emit.byte(op.LESS),
-        .LessEqual => emit.ops(&.{ op.GREATER, op.NOT }),
+        .BangEqual => emit.ops(&.{ OpCode.EQUAL, OpCode.NOT }),
+        .EqualEqual => emit.op(OpCode.EQUAL),
+        .Greater => emit.op(OpCode.GREATER),
+        .GreaterEqual => emit.ops(&.{ OpCode.LESS, OpCode.NOT }),
+        .Less => emit.op(OpCode.LESS),
+        .LessEqual => emit.ops(&.{ OpCode.GREATER, OpCode.NOT }),
         else => return, // Unreachable
     }
 }
@@ -250,25 +253,25 @@ fn unary() void {
     // Compile the operand
     parsePrecedence(Precedence.Unary);
     switch (operatorType) {
-        TokenType.Minus => emitByte(@intFromEnum(op.NEGATE)) catch @panic(BYTECODE_FAIL),
-        TokenType.Bang => emitByte(@intFromEnum(op.NOT)) catch @panic(BYTECODE_FAIL),
+        TokenType.Minus => emitByte(@intFromEnum(OpCode.NEGATE)) catch @panic(BYTECODE_FAIL),
+        TokenType.Bang => emitByte(@intFromEnum(OpCode.NOT)) catch @panic(BYTECODE_FAIL),
         else => return,
     }
 }
 /// Logical `and` operator
 fn logical_and() void {
-    const end_jump = emit.jump(op.JUMP_IF_FALSE); // Skip the right operand
-    emit.byte(op.POP); // Pop the left operand
+    const end_jump = emit.jump(OpCode.JUMP_IF_FALSE); // Skip the right operand
+    emit.op(OpCode.POP); // Pop the left operand
     parsePrecedence(Precedence.And); // Parse the right operand
     patchJump(end_jump); // Patch the jump to skip the right operand if the left operand is truthy
 }
 /// Logical `or` operator
 fn logical_or() void {
-    const elseJump = emit.jump(op.JUMP_IF_FALSE);
-    const endJump = emit.jump(op.JUMP); // if left is truthy, we jump to the end
+    const elseJump = emit.jump(OpCode.JUMP_IF_FALSE);
+    const endJump = emit.jump(OpCode.JUMP); // if left is truthy, we jump to the end
 
     patchJump(elseJump); // If left is falsey, we jump to the right operand
-    emit.byte(op.POP);
+    emit.op(OpCode.POP);
     parsePrecedence(Precedence.Or);
     patchJump(endJump); // if left was true, we jump and land here i.e. after the right operand
     // True i.e. left operand is left on the stack here.. if op.JUMP was executed, otherwise it's the value of the right operand
@@ -297,6 +300,7 @@ fn parsePrecedence(precedence: Precedence) void {
         Error("Invalid assignment target.");
     }
 }
+/// Check if the current tokenType matches the function param
 fn check(tokenType: TokenType) bool {
     return parser.current.tokenType == tokenType;
 }
@@ -309,12 +313,12 @@ fn match(tokenType: TokenType) bool {
 fn printStatement() void {
     expression();
     consume(TokenType.Semicolon, "Expect ';' after value.");
-    emitByte(@intFromEnum(op.PRINT)) catch @panic(BYTECODE_FAIL);
+    emitByte(@intFromEnum(OpCode.PRINT)) catch @panic(BYTECODE_FAIL);
 }
 fn expressionStatement() void {
     expression();
     consume(TokenType.Semicolon, "Expect ';' after expression.");
-    emitByte(@intFromEnum(op.POP)) catch @panic(BYTECODE_FAIL);
+    emitByte(@intFromEnum(OpCode.POP)) catch @panic(BYTECODE_FAIL);
 }
 fn beginScope() void {
     // Practically Safe: scopeDepth is i32
@@ -333,7 +337,7 @@ fn endScope() void {
     // Pop all locals in the current scope
     while (cc.localCount() > 0 and cc.locals.items[cc.localCount() - 1].depth > cc.scopeDepth) {
         _ = cc.locals.pop();
-        emitByte(@intFromEnum(op.POP)) catch @panic(BYTECODE_FAIL);
+        emitByte(@intFromEnum(OpCode.POP)) catch @panic(BYTECODE_FAIL);
     }
 }
 /// `offset` is the jump placeholder to be patched.
@@ -353,7 +357,7 @@ fn patchJump(placeholder_addr: usize) void {
     currentChunk().code[placeholder_addr + 1] = @intCast(jumpOffset & 0xff); // LSB
 }
 fn emitLoop(loop_start: usize) void {
-    emit.byte(op.LOOP);
+    emit.op(OpCode.LOOP);
     const offset = currentChunk().count - loop_start + 2; // +2 for the LOOP 2-byte operand which also needs to be jumped over.
     if (offset > std.math.maxInt(u16)) {
         Error("Loop body too large.");
@@ -361,32 +365,80 @@ fn emitLoop(loop_start: usize) void {
     }
     emitBytes(&[_]u8{ @truncate((offset >> 8) & 0xff), @truncate(offset & 0xff) }) catch @panic(BYTECODE_FAIL);
 }
+fn switchStatement() void {
+    consume(TokenType.LeftParen, "Expect '(' after 'switch'.");
+    expression();
+    const currentSwitchDepth = cc.switchDepth;
+    emit.op(OpCode.SWITCH_VAL);
+    emit.byte(currentSwitchDepth);
+    cc.switchDepth += 1;
+    consume(TokenType.RightParen, "Expect ')' after switch expression.");
+    consume(TokenType.LeftBrace, "Expect opening block '{' after switch expression.");
+    // To track the end of switch-case for each case; each will be patched after the entire switch statement is compiled.
+    var endJumps = std.ArrayList(usize).init(parser.allocator);
+    defer endJumps.deinit();
+
+    var seenDefault: bool = false;
+
+    while (!check(TokenType.RightBrace) and !check(TokenType.Eof)) {
+        if (match(TokenType.Case)) {
+            // Eval the case expression
+            expression();
+            consume(TokenType.Colon, "Expect ':' after 'case'.");
+            emit.op(OpCode.SWITCH_COMP);
+            emit.byte(currentSwitchDepth);
+            const jump_to_next_case = emit.jump(OpCode.JUMP_IF_FALSE);
+            emit.op(OpCode.POP); // Pop the switch comparison result from the stack
+            statement();
+            endJumps.append(emit.jump(OpCode.JUMP)) catch @panic("Out of memory: Processing case for switch statement");
+            patchJump(jump_to_next_case);
+        } else if (match(TokenType.Default)) {
+            if (seenDefault) {
+                ErrorAtCurrent("Switch statement can only have one default case.");
+                return;
+            }
+            seenDefault = !seenDefault;
+            consume(TokenType.Colon, "Expect ':' after 'default'.");
+            statement();
+        } else {
+            ErrorAtCurrent("Switch/Case can only have 'case' or 'default' statements.");
+            advance();
+        }
+    }
+    // Patch end jumps for each case
+    for (endJumps.items) |jump| {
+        patchJump(jump);
+        emit.op(OpCode.POP); // Pop the switch comparison result from the stack
+    }
+    consume(TokenType.RightBrace, "Expect '}' after switch cases.");
+    cc.switchDepth -= 1;
+}
 fn whileStatement() void {
     const loop_start = currentChunk().count;
     consume(TokenType.LeftParen, "Expect '(' after 'while'.");
     expression(); // while condition
     consume(TokenType.RightParen, "Expect ')' after condition.");
 
-    const exitJump = emit.jump(op.JUMP_IF_FALSE);
-    emit.byte(op.POP); // Pop while-condition from stack, put on stack on every iteration
+    const exitJump = emit.jump(OpCode.JUMP_IF_FALSE);
+    emit.op(OpCode.POP); // Pop while-condition from stack, put on stack on every iteration
     statement();
     emitLoop(loop_start);
     patchJump(exitJump);
-    emit.byte(op.POP); // Pop while-condition from stack when the loop exists due to condition being falsey
+    emit.op(OpCode.POP); // Pop while-condition from stack when the loop exists due to condition being falsey
 }
 fn ifStatement() void {
     consume(TokenType.LeftParen, "Expect '(' after 'if'.");
     expression(); // if condition
     consume(TokenType.RightParen, "Expect ')' after condition.");
 
-    const thenJump = emit.jump(op.JUMP_IF_FALSE);
-    emit.byte(op.POP); // Pop the condition value if condition was true
+    const thenJump = emit.jump(OpCode.JUMP_IF_FALSE);
+    emit.op(OpCode.POP); // Pop the condition value if condition was true
     statement(); // then block
 
-    const elseJump = emit.jump(op.JUMP); // jump over else block
+    const elseJump = emit.jump(OpCode.JUMP); // jump over else block
     patchJump(thenJump); // if true, we resume after the else jump instruction but before the else block
 
-    emit.byte(op.POP); // Pop the condition value, if condition was falsey
+    emit.op(OpCode.POP); // Pop the condition value, if condition was falsey
     if (match(TokenType.Else)) statement();
     patchJump(elseJump);
 }
@@ -408,16 +460,16 @@ fn forStatement() void {
     if (!match(TokenType.Semicolon)) {
         expression();
         consume(TokenType.Semicolon, "Expect ';' after loop condition.");
-        exitJump = emit.jump(op.JUMP_IF_FALSE);
-        emit.byte(op.POP);
+        exitJump = emit.jump(OpCode.JUMP_IF_FALSE);
+        emit.op(OpCode.POP);
     }
     // < For loop condition end
     // > For loop increment clause
     if (!match(TokenType.RightParen)) {
-        const bodyJump = emit.jump(op.JUMP); // Jump to the loop body without executing the increment clause
+        const bodyJump = emit.jump(OpCode.JUMP); // Jump to the loop body without executing the increment clause
         const incrementStart = currentChunk().count;
         expression();
-        emit.byte(op.POP); // Pop the increment value
+        emit.op(OpCode.POP); // Pop the increment value
         consume(TokenType.RightParen, "Expect ')' after for clauses.");
         emitLoop(loop_start); // Jump back to the start of the loop
         loop_start = incrementStart; // Update loop_start to the start of the increment clause
@@ -430,7 +482,7 @@ fn forStatement() void {
     emitLoop(loop_start);
     if (exitJump) |exit_jump| {
         patchJump(exit_jump);
-        emit.byte(op.POP);
+        emit.op(OpCode.POP);
     }
     endScope();
 }
@@ -453,6 +505,10 @@ fn statement() void {
         TokenType.If => {
             advance();
             ifStatement();
+        },
+        TokenType.Switch => {
+            advance();
+            switchStatement();
         },
         TokenType.While => {
             advance();
@@ -561,7 +617,7 @@ fn defineVariable(global: usize) void {
         markInitialized();
         return;
     }
-    emitU16Op(op.DEFINE_GLOBAL, global) catch @panic("Failed to emit DEFINE_GLOBAL bytecode");
+    emitU16Op(OpCode.DEFINE_GLOBAL, global) catch @panic("Failed to emit DEFINE_GLOBAL bytecode");
 }
 /// Emit bytecode for a declaration
 fn declaration() void {
@@ -693,12 +749,12 @@ inline fn endCompiler(allocator: std.mem.Allocator) !void {
     try emitReturn();
 }
 inline fn emitReturn() !void {
-    try emitByte(@intFromEnum(op.RETURN));
+    try emitByte(@intFromEnum(OpCode.RETURN));
 }
 
 const std = @import("std");
 const Chunk = @import("chunk.zig").Chunk;
-const op = @import("opcode.zig").OpCode;
+const OpCode = @import("opcode.zig").OpCode;
 const Token = @import("scanner.zig").Token;
 const TokenType = @import("scanner.zig").TokenType;
 const Scanner = @import("scanner.zig");
@@ -826,6 +882,14 @@ const rules = [_]ParseRule{
     ParseRule{ .prefix = null, .infix = null, .precedence = Precedence.None },
     // TOKEN_MODULO
     ParseRule{ .prefix = null, .infix = binary, .precedence = Precedence.Factor },
+    // TOKEN_SWITCH
+    ParseRule{ .prefix = null, .infix = null, .precedence = Precedence.None },
+    // TOKEN_CASE
+    ParseRule{ .prefix = null, .infix = null, .precedence = Precedence.None },
+    // TOKEN_DEFAULT
+    ParseRule{ .prefix = null, .infix = null, .precedence = Precedence.None },
+    // TOKEN_COLON
+    ParseRule{ .prefix = null, .infix = null, .precedence = Precedence.None },
 };
 
 const CompilationResult = struct {
@@ -845,6 +909,8 @@ pub const Compiler = struct {
     stringTable: Table,
     /// Current chunk being compiled
     compilingChunk: *Chunk,
+    /// Switch depth
+    switchDepth: u8 = 0,
 
     // Use same hash across table/objstring,
     // NOTE: ObjString still uses loxHash, but the HashTable uses Clhash if available. This doesn't matter for checking values

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -50,6 +50,8 @@ pub fn disassembleInstruction(chunk: *const Chunk, byte_offset: usize, allocator
         .EQUAL => return simpleInstruction("OP_EQUAL", byte_offset, src_info),
         .PRINT => return simpleInstruction("OP_PRINT", byte_offset, src_info),
         .POP => return simpleInstruction("OP_POP", byte_offset, src_info),
+        .SWITCH_COMP => return simpleInstruction("OP_SWITCH_COMP", byte_offset, src_info),
+        .SWITCH_VAL => return simpleInstruction("OP_SWITCH_VAL", byte_offset, src_info),
         .DEFINE_GLOBAL => return constantU16Instruction("OP_DEFINE_GLOBAL", chunk, byte_offset, src_info),
         .GET_GLOBAL => return constantU16Instruction("OP_GET_GLOBAL", chunk, byte_offset, src_info),
         .SET_GLOBAL => return constantU16Instruction("OP_SET_GLOBAL", chunk, byte_offset, src_info),

--- a/src/error.zig
+++ b/src/error.zig
@@ -31,6 +31,8 @@ pub const RuntimeError = error{
     InvalidComparison,
     CannotAddDifferentTypes,
     GlobalNotFound,
+    SwitchDepthExceeded,
+    SwitchStackEmpty,
 };
 pub fn formatRuntimeError(err: RuntimeError) []const u8 {
     return switch (err) {
@@ -45,5 +47,7 @@ pub fn formatRuntimeError(err: RuntimeError) []const u8 {
         RuntimeError.InvalidComparison => "Invalid operands for comparison",
         RuntimeError.CannotAddDifferentTypes => "Operands of different types cannot be added",
         RuntimeError.GlobalNotFound => "Undefined global variable",
+        RuntimeError.SwitchDepthExceeded => "Nested switch depth maximum exceeded",
+        RuntimeError.SwitchStackEmpty => "Switch stack is empty",
     };
 }

--- a/src/opcode.zig
+++ b/src/opcode.zig
@@ -34,4 +34,6 @@ pub const OpCode = enum(u8) {
     JUMP,
     JUMP_IF_FALSE,
     LOOP,
+    SWITCH_VAL,
+    SWITCH_COMP,
 };

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -102,8 +102,8 @@ fn identifierType(sc: *Scanner) TokenType {
             }
             switch (sc.source[sc.start + 1]) {
                 'a' => return sc.checkKeyword(2, 2, "se", TokenType.Case),
-                'o' => return sc.checkKeyword(2, 4, "ntinue", TokenType.Continue),
-                'l' => return sc.checkKeyword(2, 4, "ass", TokenType.Class),
+                // 'o' => return sc.checkKeyword(2, 6, "ntinue", TokenType.Continue),
+                'l' => return sc.checkKeyword(2, 3, "ass", TokenType.Class),
                 else => return TokenType.Identifier,
             }
         },
@@ -119,7 +119,7 @@ fn identifierType(sc: *Scanner) TokenType {
                 return TokenType.Identifier;
             }
             switch (sc.source[sc.start + 1]) {
-                'w' => return sc.checkKeyword(2, 3, "itch", TokenType.Switch),
+                'w' => return sc.checkKeyword(2, 4, "itch", TokenType.Switch),
                 'u' => return sc.checkKeyword(2, 3, "per", TokenType.Super),
                 else => return TokenType.Identifier,
             }
@@ -207,6 +207,7 @@ pub fn scanToken(sc: *Scanner) Token {
         '/' => return makeToken(sc, TokenType.Slash),
         '*' => return makeToken(sc, TokenType.Star),
         '%' => return makeToken(sc, TokenType.Modulo),
+        ':' => return makeToken(sc, TokenType.Colon),
         '!' => return if (sc.match('='))
             makeToken(sc, TokenType.BangEqual)
         else
@@ -319,4 +320,5 @@ pub const TokenType = enum(u8) {
     Switch,
     Case,
     Default,
+    Colon,
 };

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -96,14 +96,34 @@ fn checkKeyword(sc: *Scanner, start: usize, length: usize, rest: []const u8, key
 fn identifierType(sc: *Scanner) TokenType {
     switch (sc.source[sc.start]) {
         'a' => return sc.checkKeyword(1, 2, "nd", TokenType.And),
-        'c' => return sc.checkKeyword(1, 4, "lass", TokenType.Class),
+        'c' => {
+            if (sc.current - sc.start == 1) {
+                return TokenType.Identifier;
+            }
+            switch (sc.source[sc.start + 1]) {
+                'a' => return sc.checkKeyword(2, 2, "se", TokenType.Case),
+                'o' => return sc.checkKeyword(2, 4, "ntinue", TokenType.Continue),
+                'l' => return sc.checkKeyword(2, 4, "ass", TokenType.Class),
+                else => return TokenType.Identifier,
+            }
+        },
+        'd' => return sc.checkKeyword(1, 6, "efault", TokenType.Default),
         'e' => return sc.checkKeyword(1, 3, "lse", TokenType.Else),
         'i' => return sc.checkKeyword(1, 1, "f", TokenType.If),
         'n' => return sc.checkKeyword(1, 2, "il", TokenType.Nil),
         'o' => return sc.checkKeyword(1, 1, "r", TokenType.Or),
         'p' => return sc.checkKeyword(1, 4, "rint", TokenType.Print),
         'r' => return sc.checkKeyword(1, 5, "eturn", TokenType.Return),
-        's' => return sc.checkKeyword(1, 4, "uper", TokenType.Super),
+        's' => {
+            if (sc.current - sc.start == 1) {
+                return TokenType.Identifier;
+            }
+            switch (sc.source[sc.start + 1]) {
+                'w' => return sc.checkKeyword(2, 3, "itch", TokenType.Switch),
+                'u' => return sc.checkKeyword(2, 3, "per", TokenType.Super),
+                else => return TokenType.Identifier,
+            }
+        },
         'v' => return sc.checkKeyword(1, 2, "ar", TokenType.Var),
         'w' => return sc.checkKeyword(1, 4, "hile", TokenType.While),
         'f' => {
@@ -296,4 +316,7 @@ pub const TokenType = enum(u8) {
 
     // Extensions
     Modulo, // '%'
+    Switch,
+    Case,
+    Default,
 };

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1,4 +1,6 @@
 const STACK_MAX = (1 << 16) + 1024; // u16 max locals + 1024 for temporaries.
+const MAX_SWITCH_DEPTH = 64; // Arbitrary limit for switch stack depth
+
 pub const VM = @This();
 pub const stdout = std.io.getStdOut().writer();
 const stderr = std.io.getStdErr().writer();
@@ -24,6 +26,12 @@ stringTable: Table,
 globals: Table,
 /// Cache for global variables
 globalCache: GlobalCache,
+/// Switch stack
+switchStack: std.BoundedArray(Value, MAX_SWITCH_DEPTH),
+
+inline fn switchDepth(self: *VM) usize {
+    return self.switchStack.len;
+}
 
 const GlobalCache = struct {
     const GlobalCacheEntry = struct {
@@ -77,6 +85,11 @@ pub fn initVM(allocator: std.mem.Allocator) VM {
         .stringTable = Table.init(allocator),
         .globals = Table.init(allocator),
         .globalCache = GlobalCache.init(),
+        .switchStack = std.BoundedArray(Value, MAX_SWITCH_DEPTH).init(0) catch |err| {
+            // We fail silently here, as the switch-case is not a critical lox language feature but an extension.
+            std.debug.print("Error initializing switch stack: {any}\nSwitch-cases not avaialble", .{err});
+            std.process.exit(101);
+        },
     };
 }
 pub fn deinitVM(self: *VM) void {
@@ -399,6 +412,29 @@ fn run(self: *VM, stack_tracing: bool) RuntimeError!void {
                 const offset = self.readU16();
                 self.ip -= offset;
             },
+            .SWITCH_VAL => {
+                const depth = self.readByte();
+                if (depth >= MAX_SWITCH_DEPTH) {
+                    self.runtimeError("Switch value with invalid depth 0x{x:0>2} (max: {d})", .{ depth, MAX_SWITCH_DEPTH });
+                    return RuntimeError.SwitchDepthExceeded;
+                }
+                self.switchStack.set(depth, try self.pop()); // Pops the switch value and store in vm.switchStack
+            },
+            .SWITCH_COMP => {
+                if (self.switchDepth() == 0) {
+                    self.runtimeError("Switch comparison without a switch value, [invalid depth: 0x{x:0>2}]", .{self.readByte()});
+                    return RuntimeError.SwitchStackEmpty;
+                }
+                const depth = self.readByte();
+                if (depth >= MAX_SWITCH_DEPTH) {
+                    self.runtimeError("Switch value with invalid depth 0x{x:0>2} (max: {d})", .{ depth, MAX_SWITCH_DEPTH });
+                    return RuntimeError.SwitchDepthExceeded;
+                }
+                const switch_value: Value = self.switchStack.get(depth);
+                const case_value = try self.pop();
+                try self.push(Value{ .Bool = switch_value.isEqual(&case_value) });
+            },
+
             // else => {
             //     self.runtimeError("Unknown opcode: {d}", .{@intFromEnum(instruction)});
             //     return RuntimeError.UnknownOpCode;

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -418,7 +418,9 @@ fn run(self: *VM, stack_tracing: bool) RuntimeError!void {
                     self.runtimeError("Switch value with invalid depth 0x{x:0>2} (max: {d})", .{ depth, MAX_SWITCH_DEPTH });
                     return RuntimeError.SwitchDepthExceeded;
                 }
-                self.switchStack.set(depth, try self.pop()); // Pops the switch value and store in vm.switchStack
+                if (depth == self.switchStack.len) {
+                    self.switchStack.append(try self.pop()) catch {};
+                } else self.switchStack.set(depth, try self.pop()); // Pops the switch value and store in vm.switchStack
             },
             .SWITCH_COMP => {
                 if (self.switchDepth() == 0) {


### PR DESCRIPTION
Writing this code is now possible:

```c
// programs/switch-case.lox
var a = 223;

switch (a) {
    case 1: print "not expected"; // Single-line statement doesn't need braces.
    // Use blocks for multi-line statements.
    case 220 + 3: switch (4) {
        case 4: print "nested switch"; // This will execute if the outer case matches.
        default: print "nested default"; // This will execute if the inner switch doesn't match.
    }
    case 33: print "not expected"; // No `break` required, only one case will match and execute.
    default: print "default case"; // Default case will execute if no other case matches.
}
```
Closes #17 